### PR TITLE
Add Coerce impl for Option of reference

### DIFF
--- a/vgtk/src/properties.rs
+++ b/vgtk/src/properties.rs
@@ -95,6 +95,12 @@ where
     }
 }
 
+impl<'a, A> PropertyValueCoerce<'a, Option<&'a A>> for Option<A> {
+    fn property_coerce(value: &'a Option<A>) -> Option<&'a A> {
+        value.as_ref()
+    }
+}
+
 impl<'a> PropertyValueCompare<'a, &'a str> for String {
     fn property_compare(left: &str, right: &String) -> bool {
         left == right


### PR DESCRIPTION
I needed this to be able to instantiate a `TreeView` with a model. It's not pretty, since `set_model` wants an `Option<&TreeModel>`.

I have no clue what the implications of this are, all I've done here is try and find the smallest diff to make the compiler errors go away without losing my mind.

This works, with a bit of manual trickery (see [here](https://github.com/killercup/zfs-gui-thing/blob/2c3f9a1e91d56cf139b0203a81905967ecd3e774/src/main.rs#L69-L79)).