### PR TITLE
Support custom titles in HeaderBar

### DIFF
--- a/vgtk/src/ext/mod.rs
+++ b/vgtk/src/ext/mod.rs
@@ -12,7 +12,7 @@ use gio::{Action, ActionExt, ApplicationFlags};
 use glib::{GString, IsA, Object, ObjectExt};
 use gtk::{
     Application, ApplicationWindowExt, BoxExt, GridExt, GtkApplicationExt, GtkWindowExt, ImageExt,
-    LabelExt, Widget, Window, WindowPosition, WindowType,
+    LabelExt, HeaderBarExt, Widget, Window, WindowPosition, WindowType,
 };
 
 use colored::Colorize;
@@ -183,6 +183,22 @@ pub trait BoxExtHelpers: BoxExt {
 }
 
 impl<A> BoxExtHelpers for A where A: BoxExt {}
+
+/// Helper trait for [`HeaderBar`][HeaderBar].
+///
+/// [HeaderBar]: ../../gtk/struct.HeaderBar.html
+pub trait HeaderBarExtHelpers: HeaderBarExt {
+    fn get_child_custom_title<P: IsA<Widget>>(&self, _child: &P) -> bool {
+        // Always compare true, it's all taken care of in add_child().
+        true
+    }
+
+    fn set_child_custom_title<P: IsA<Widget>>(&self, _child: &P, _center: bool) {
+        // This is handled by add_child() rules. The setter is a no-op.
+    }
+}
+
+impl<A> HeaderBarExtHelpers for A where A: HeaderBarExt {}
 
 /// Helper trait for [`Image`][Image].
 ///

--- a/vgtk/src/vdom/gtk_state.rs
+++ b/vgtk/src/vdom/gtk_state.rs
@@ -5,6 +5,7 @@ use glib::{prelude::*, Object, SignalHandlerId};
 use gtk::{
     self, prelude::*, Application, ApplicationWindow, Bin, Box as GtkBox, Builder, Container,
     Dialog, Grid, GridExt, Menu, MenuButton, MenuItem, ShortcutsWindow, Widget, Window,
+    HeaderBar
 };
 
 use super::State;
@@ -168,6 +169,23 @@ fn add_child<Model: Component>(
         } else {
             panic!(
                 "Box's children must be Widgets, but {} was found.",
+                child.get_type()
+            );
+        }
+    } else if let Some(parent) = parent.downcast_ref::<HeaderBar>() {
+        // HeaderBar: added normally, except one widget can be added using
+        // set_custom_title if it has the custom_title=true child property
+        // (which is faked in ext.rs). More than one child with this property is
+        // undefined behaviour.
+        if let Some(widget) = child.downcast_ref::<Widget>() {
+            if child_spec.get_child_prop("custom_title").is_some() {
+                parent.set_custom_title(Some(widget));
+            } else {
+                parent.add(widget);
+            }
+        } else {
+            panic!(
+                "HeaderBar's children must be Widgets, but {} was found.",
                 child.get_type()
             );
         }


### PR DESCRIPTION
I couldn't figure out how to do this without special support, so I copied the `center_widget` trick.