### PR TITLE
Implement Notebook::tab_label_text child property.

### DIFF
--- a/vgtk/src/ext/mod.rs
+++ b/vgtk/src/ext/mod.rs
@@ -9,10 +9,10 @@
 
 use gdk_pixbuf::Pixbuf;
 use gio::{Action, ActionExt, ApplicationFlags};
-use glib::{GString, IsA, Object, ObjectExt};
+use glib::{GString, IsA, Object, ObjectExt, object::Cast};
 use gtk::{
     Application, ApplicationWindowExt, BoxExt, GridExt, GtkApplicationExt, GtkWindowExt, ImageExt,
-    LabelExt, HeaderBarExt, Widget, Window, WindowPosition, WindowType,
+    LabelExt, NotebookExt, HeaderBarExt, Widget, Window, WindowPosition, WindowType,
 };
 
 use colored::Colorize;
@@ -221,6 +221,26 @@ pub trait LabelExtHelpers: LabelExt {
 }
 
 impl<A> LabelExtHelpers for A where A: LabelExt {}
+
+/// Helper trait for [`Notebook`][Notebook].
+///
+/// [Notebook]: ../../gtk/struct.Notebook.html
+pub trait NotebookExtHelpers: NotebookExt {
+    fn set_child_tab_label_text(&self, child: &Object, label: &str) {
+        if let Some(w) = child.downcast_ref::<Widget>() {
+            self.set_tab_label_text(w, label)
+        }
+    }
+    fn get_child_tab_label_text(&self, child: &Object) -> Option<GString> {
+        if let Some(w) = child.downcast_ref::<Widget>() {
+            self.get_tab_label_text(w)
+        } else {
+            None
+        }
+    }
+}
+
+impl<A> NotebookExtHelpers for A where A: NotebookExt {}
 
 /// Helper trait for [`Grid`][Grid] layout.
 ///


### PR DESCRIPTION
This is not the most flexible interface, but handles the simple case of notebooks with textual tab labels.

I'd appreciate review about `object::Cast`; I couldn't get a simple usage setting `Notebook::tab_label_text` to a string literal to typecheck with a `<P: IsA<...>>` bound of `Object` or `Widget` for the child parameter. Am I missing things or is the flexibility of dynamic casting necessary here?