### PR TITLE
Implement `Notebook::action_widget_{start,end}`

### DIFF
--- a/vgtk/src/ext/mod.rs
+++ b/vgtk/src/ext/mod.rs
@@ -12,7 +12,7 @@ use gio::{Action, ActionExt, ApplicationFlags};
 use glib::{GString, IsA, Object, ObjectExt};
 use gtk::{
     Application, ApplicationWindowExt, BoxExt, GridExt, GtkApplicationExt, GtkWindowExt, ImageExt,
-    LabelExt, HeaderBarExt, Widget, Window, WindowPosition, WindowType,
+    LabelExt, NotebookExt, HeaderBarExt,  Widget, Window, WindowPosition, WindowType,
 };
 
 use colored::Colorize;
@@ -221,6 +221,28 @@ pub trait LabelExtHelpers: LabelExt {
 }
 
 impl<A> LabelExtHelpers for A where A: LabelExt {}
+
+/// Helper trait for [`Notebook`][Notebook].
+///
+/// [Notebook]: ../../gtk/struct.Notebook.html
+pub trait NotebookExtHelpers: NotebookExt {
+    fn set_child_action_widget_start<P: IsA<Widget>>(&self, _child: &P, _val: bool) {
+        // This is handled by add_child() rules. The setter is a no-op.
+    }
+    fn get_child_action_widget_start<P: IsA<Widget>>(&self, _child: &P) -> bool {
+        // Always compare true, it's all taken care of in add_child().
+        true
+    }
+    fn set_child_action_widget_end<P: IsA<Widget>>(&self, _child: &P, _val: bool) {
+        // This is handled by add_child() rules. The setter is a no-op.
+    }
+    fn get_child_action_widget_end<P: IsA<Widget>>(&self, _child: &P) -> bool {
+        // Always compare true, it's all taken care of in add_child().
+        true
+    }
+}
+
+impl<A> NotebookExtHelpers for A where A: NotebookExt {}
 
 /// Helper trait for [`Grid`][Grid] layout.
 ///

--- a/vgtk/src/vdom/gtk_state.rs
+++ b/vgtk/src/vdom/gtk_state.rs
@@ -4,8 +4,8 @@ use gio::{Action, ActionExt, ActionMapExt};
 use glib::{prelude::*, Object, SignalHandlerId};
 use gtk::{
     self, prelude::*, Application, ApplicationWindow, Bin, Box as GtkBox, Builder, Container,
-    Dialog, Grid, GridExt, Menu, MenuButton, MenuItem, ShortcutsWindow, Widget, Window,
-    HeaderBar
+    Dialog, Grid, GridExt, Menu, MenuButton, MenuItem, Notebook, ShortcutsWindow, Widget,
+    Window, HeaderBar
 };
 
 use super::State;
@@ -199,6 +199,25 @@ fn add_child<Model: Component>(
         } else {
             panic!(
                 "Grid's children must be Widgets, but {} was found.",
+                child.get_type()
+            );
+        }
+    } else if let Some(parent) = parent.downcast_ref::<Notebook>() {
+        // Notebook: added normally, except one widget can be added using
+        // set_action_widget if it has the action_widget_start or
+        // action_widget_end child property (which are faked in ext.rs). More
+        // than one child with each of these properties is undefined behaviour.
+        if let Some(widget) = child.downcast_ref::<Widget>() {
+            if child_spec.get_child_prop("action_widget_start").is_some() {
+                parent.set_action_widget(widget, gtk::PackType::Start);
+            } else if child_spec.get_child_prop("action_widget_end").is_some() {
+                parent.set_action_widget(widget, gtk::PackType::End);
+            } else {
+                parent.add(widget);
+            }
+        } else {
+            panic!(
+                "Notebook's children must be Widgets, but {} was found.",
                 child.get_type()
             );
         }


### PR DESCRIPTION
This enables setting Notebook action widgets (such as a '+' for opening new tabs) from vgtk.