### PR TITLE
Implement Notebook append_page with tab_label widget

### DIFF
--- a/vgtk/src/ext/mod.rs
+++ b/vgtk/src/ext/mod.rs
@@ -240,6 +240,13 @@ pub trait NotebookExtHelpers: NotebookExt {
         // Always compare true, it's all taken care of in add_child().
         true
     }
+    fn set_child_tab_with_label<P: IsA<Widget>>(&self, _child: &P, _val: bool) {
+        // This is handled by add_child() rules. The setter is a no-op.
+    }
+    fn get_child_tab_with_label<P: IsA<Widget>>(&self, _child: &P) -> bool {
+        // Always compare true, it's all taken care of in add_child().
+        true
+    }
 }
 
 impl<A> NotebookExtHelpers for A where A: NotebookExt {}

--- a/vgtk/src/vdom/gtk_state.rs
+++ b/vgtk/src/vdom/gtk_state.rs
@@ -216,8 +216,8 @@ fn add_child<Model: Component>(
             }else if child_spec.get_child_prop("tab_with_label").is_some() {
                 if let Some(widget) = child.downcast_ref::<gtk::Box>() {
                     let mut container = widget.get_children();
-                    let content = container.pop().unwrap();
-                    let label = container.pop().unwrap();
+                    let content = container.pop().expect("Tab item content is missing");
+                    let label = container.pop().expect("Tab item label is missing");
                     widget.remove(&content);
                     widget.remove(&label);
                     parent.remove(widget);


### PR DESCRIPTION
This change allows to add tab items to a notebook with a custom widget as label. Useful if you want to implement a close button in the tab.
`
<Notebook>

                <Box Notebook::tab_with_label=true>
                    <Box>
                        <Label text=tab.clone() />
                        <Button label="Close" on clicked=|_| {
                            Message::RemoveTab(idx)
                        } />
                    </Box>
                    <Box orientation=Orientation::Vertical>
                        {self.get_tab_view(&schema)}
                    </Box>
                </Box>

</Notebook>
`

