### PR TITLE
Don't build documentation for every build

### DIFF
--- a/vgtk/Cargo.toml
+++ b/vgtk/Cargo.toml
@@ -12,6 +12,9 @@ readme = "../README.md"
 categories = ["gui"]
 keywords = ["gtk"]
 
+[features]
+dox = ["gtk/embed-lgpl-docs"]
+
 [dependencies]
 gio = "0.9.0"
 glib = "0.10.0"
@@ -26,4 +29,7 @@ futures = "0.3.5"
 
 [dependencies.gtk]
 version = "0.9.0"
-features = ["embed-lgpl-docs", "v3_20"]
+features = ["v3_20"]
+
+[package.metadata.docs.rs]
+features = ["dox"]


### PR DESCRIPTION
It's really bad for compilation times to build gtk-rs documentation when unneeded. However, I can add a note in the README.md to tell people to enable the `dox` feature if they want it full?

Would be much simpler if we had a way to tell what features to use by default when running rustdoc but I guess it's another debate. ;)