### PR TITLE
update dead documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ fn main() {
 ## Installation
 
 You'll need to ensure GTK is installed and usable on your system before you can use `vgtk`. Please
-consult the [Gtk-rs requirements doc](https://gtk-rs.org/docs/requirements.html) for detailed
+consult the [Gtk documentation](https://www.gtk.org/docs/installations/) for detailed
 instructions. It can be especially involved on Windows, but if you follow their instructions
 carefully, it does eventually work.
 


### PR DESCRIPTION
The original link does not exist anymore. The main gtk-rs doc page has a requirements section that just points to gtk proper, so I've updated the link to point there, which seems to be the closest match for getting gtk installed, in particular on Windows.

Stand by as I follow these instructions and yell at my screen...