### PR TITLE
allow non-unit signal return values

### DIFF
--- a/macros/src/gtk.rs
+++ b/macros/src/gtk.rs
@@ -276,14 +276,18 @@ pub fn expand_handler(
             vgtk::lib::glib::MainContext::ref_thread_default().spawn_local(
                 async move {
                     let msg = async move { #body_s }.await;
+                    let ret = msg.into_signal_return();
                     scope.send_message(msg);
+                    ret
                 }
             )
         })
     } else {
         quote!({
             let msg = { #body_s };
+            let ret = msg.into_signal_return();
             scope.send_message(msg);
+            ret
         })
     };
     quote!(

--- a/vgtk/src/ext/mod.rs
+++ b/vgtk/src/ext/mod.rs
@@ -392,3 +392,15 @@ where
         self.get_cell_height(child)
     }
 }
+
+/// A trait for converting a callback message type into a callback return type
+/// Most callbacks return (), but some require a boolean or enum.
+/// A blanked implentation is provided for (), but other conversions are user-defined
+pub trait IntoSignalReturn<T>: Sized {
+    /// Convert message to callback return type
+    fn into_signal_return(&self) -> T;
+}
+
+impl<T> IntoSignalReturn<()> for T {
+    fn into_signal_return(&self) { }
+}


### PR DESCRIPTION
As per #39 some signals do not return `()` but rather `Inhibit(bool)` or similar flags.

This PR introduces a `IntoSignalReturn` trait that has a blanket implementation for converting types into `()`. This trait is then used to create the return value of the signal callbacks. It will automatically convert any message to `()`, and allows the user to implement custom conversions, as follows:

```
impl IntoSignalReturn<Inhibit> for Message {
    fn into_signal_return(&self) -> Inhibit {
        Inhibit(false)
    }
}
```

My main concern is if this handles all cases, or needs special handling for subcomponents as @LiHRaM seemed to suggest. @bodil any input?