### PR TITLE
Don't crash when app is actived twice

### DIFF
--- a/examples/todomvc/src/app.rs
+++ b/examples/todomvc/src/app.rs
@@ -63,6 +63,7 @@ impl Model {
     }
 
     fn main_panel(&self) -> VNode<Model> {
+        #![allow(clippy::field_reassign_with_default)]
         gtk! {
             <Box spacing=10 orientation=Orientation::Vertical>
                 <Box spacing=10 orientation=Orientation::Horizontal Box::expand=false>

--- a/examples/todomvc/src/app.rs
+++ b/examples/todomvc/src/app.rs
@@ -63,7 +63,6 @@ impl Model {
     }
 
     fn main_panel(&self) -> VNode<Model> {
-        #![allow(clippy::field_reassign_with_default)]
         gtk! {
             <Box spacing=10 orientation=Orientation::Vertical>
                 <Box spacing=10 orientation=Orientation::Horizontal Box::expand=false>

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(can_show_location_of_runtime_parse_error, feature(proc_macro_span))]
 #![deny(rust_2018_idioms, unsafe_code)]
+#![allow(unused_extern_crates)]
 
 #[allow(clippy::useless_attribute)]
 extern crate proc_macro;


### PR DESCRIPTION
Gtk will call the activate signal again if the binary
is executed while the app is already running.  Ideally
one would handle it in a better way, such as by bringing
the main application window forward.  This commit
is a first step in that direction, at least making sure
that the app doesn't crash.